### PR TITLE
set __USE_MINGW_ANSI_STDIO=1 to let vsnprintf in mingw64 conform with ANSI

### DIFF
--- a/builder/MyBuilder.pm
+++ b/builder/MyBuilder.pm
@@ -12,6 +12,7 @@ sub new {
     $class->SUPER::new(
         @_,
         c_source => [qw(hoedown/src/)],
+        ($^O eq 'MSWin32' ? (extra_compiler_flags => ['-D__USE_MINGW_ANSI_STDIO=1']) : ()),
     );
 }
 


### PR DESCRIPTION
With this fix, T::M::Hoedown passes 02_toc.t under Win32 (tested with strawberry 64bit).

Related links:
- http://www.mail-archive.com/mingw-w64-public@lists.sourceforge.net/msg08018.html
- http://git.videolan.org/?p=ffmpeg.git;a=commitdiff;h=8bdbabfaa46989b1a0e82d2df0a27df32277294d
